### PR TITLE
Removed stale comment for retrieving a project

### DIFF
--- a/client.go
+++ b/client.go
@@ -394,7 +394,6 @@ func (c *Client) OrganizationProjects(ctx context.Context, orgID string) (Projec
 }
 
 // OrganizationProject gets a Project object.
-// NOT WORKING RIGHT NOW
 func (c *Client) OrganizationProject(ctx context.Context, orgID, projectID string) (*Project, error) {
 	project := &Project{}
 


### PR DESCRIPTION
Removed comment suggesting retrieving a single project from an organization is not working yet.

The API for retrieving a single project from an organization now works. see the [Snyk API reference](https://snyk.docs.apiary.io/#reference/projects/individual-project/retrieve-a-single-project)