### PR TITLE
Added Project field RemoteRepoUrl

### DIFF
--- a/client.go
+++ b/client.go
@@ -367,6 +367,7 @@ type Project struct {
 		Email    string `json:"email"`
 	} `json:"owner"`
 	BrowseUrl       string `json:"browseUrl,omitempty"`
+	RemoteRepoUrl   string `json:"remoteRepoUrl,omitempty"`
 	IsMonitored     bool   `json:"isMonitored"`
 	Branch          string `json:"branch,omitempty"`
 	TargetReference string `json:"targetReference,omitempty"`


### PR DESCRIPTION
Added the field named RemoteRepoUrl from the Snyk API response.
Was working with badly named projects in Snyk and realized that this field was missing.